### PR TITLE
Use node role as a constraint

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
         condition: any
       placement:
         constraints:
-           - node.hostname == dockertoolbox.com
+           - node.role==manager
     volumes:
       - jenkins_data:/var/jenkins_home
       - /var/run/docker.sock:/var/run/docker.sock


### PR DESCRIPTION
Using `node.hostname == dockertoolbox.com` as a constraint is very dependent on the apprenant local machine, and if s.he used a different name, the service replicas would not start and the encountered error is not obvious to understand. 

```
> docker service ps jenkins_jenkins --no-trunc
...   NAME                 ...   ERROR 
...   jenkins_jenkins.1    ...   "no suitable node (scheduling constraints not satisfied on 2 nodes)"
```

Using `node.role==manager` seems to be more suitable for the tutorial